### PR TITLE
[FIX] hostname -i with lowerecase

### DIFF
--- a/local-cli/generator-desktop/templates/run-app.sh.in
+++ b/local-cli/generator-desktop/templates/run-app.sh.in
@@ -13,7 +13,7 @@ plugins_path=""
 asset_path="share"
 executor=""
 
-react_host=`hostname -I`
+react_host=`hostname -i`
 
 # Parse args
 for arg in "$@"

--- a/local-cli/templates/HelloWorld/desktop/run-app.sh.in
+++ b/local-cli/templates/HelloWorld/desktop/run-app.sh.in
@@ -13,7 +13,7 @@ plugins_path=""
 asset_path="share"
 executor=""
 
-react_host=`hostname -I`
+react_host=`hostname -i`
 
 # Parse args
 for arg in "$@"


### PR DESCRIPTION
On linux with GNU ineturils 1.9.4 (current stable release) the use of an uppercase hostname info causes error

```
➜  ~ hostname -I                                        ~
hostname: invalid option -- 'I'
Try 'hostname --help' or 'hostname --usage' for more information.
```

but lowercase works

```
➜  ~ hostname -i                                        ~
127.0.1.1 
```

Not sure if this cross platform command, I'd only assume so that it works on MacOs too, if not, maybe there needs to be a boolean there before.